### PR TITLE
Added comment to replace content hub instance url

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Add another component by clicking the plus sign within a column to your likings,
 * Control name: Custom.Controls.PublicLinksPreview
 * Resources: https://cdn.jsdelivr.net/npm/handlebars@latest/dist/handlebars.js
 * Code: [External page components/Public links preview.js](External%20page%20components/Public%20links%20preview.js)
+  * Replace two references of https://playground.stylelabs.io/ with your content hub instance url
 * Template: [External page components/Public links preview.html](External%20page%20components/Public%20links%20preview.html)
 
 Save and close the newly added component and go to an asset to verify correct placement of both new components.


### PR DESCRIPTION
When creating the second _External_ component the code has two references to a Content Hub instance. Those reference needs to be updated by the person who implements the script. I've added a line to the README to bring to the attention of the reader.
